### PR TITLE
Added SunXi GPIO Support

### DIFF
--- a/Sources/SunXi.swift
+++ b/Sources/SunXi.swift
@@ -1,0 +1,71 @@
+//
+//  SunXi.swift
+//  
+//
+//  Created by Alsey Coleman Miller on 6/7/16.
+//  Copyright © 2016 PureSwift. All rights reserved.
+//
+
+/// GPIO for SunXi (e.g. OrangePi) hardware. 
+///
+/// - SeeAlso: [SunXi Wiki](http://linux-sunxi.org/GPIO)
+public struct SunXiGPIO: CustomStringConvertible, Equatable {
+    
+    // MARK: - Properties
+    
+    public var letter: Letter
+    
+    public var pin: UInt
+    
+    // MARK: - Initialization
+    
+    public init(letter: Letter, pin: UInt) {
+        
+        self.letter = letter
+        self.pin = pin
+    }
+    
+    // MARK: - Computed Properties
+    
+    public var description: String {
+        
+        return pinName
+    }
+    
+    public var pinName: String {
+        
+        return "P" + "\(letter)" + "\(pin)"
+    }
+    
+    public var gpioPin: Int {
+        
+        return (letter.rawValue * 32) + Int(pin)
+    }
+}
+
+// MARK: - Equatable
+
+public func == (lhs: SunXiGPIO, rhs: SunXiGPIO) -> Bool {
+    
+    return lhs.letter == rhs.letter && lhs.pin == rhs.pin
+}
+
+// MARK: - Supporting Types
+
+public extension SunXiGPIO {
+    
+    public enum Letter: Int {
+        
+        case A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z
+    }
+}
+
+// MARK: - Extensions
+
+public extension GPIO {
+    
+    convenience init(sunXi: SunXiGPIO) {
+        
+        self.init(name: sunXi.pinName, id: sunXi.gpioPin)
+    }
+}


### PR DESCRIPTION
Helper struct that will dynamically (and safely) calculate the GPIO pin number for any SunXi hardware (e.g. Orange Pi).