### PR TITLE
UnsafeMutablePointer API Change

### DIFF
--- a/Sources/SwiftyGPIO.swift
+++ b/Sources/SwiftyGPIO.swift
@@ -150,7 +150,7 @@ extension GPIO {
         let fp = fopen(path,"r")
         var res:String?
         if fp != nil {
-            let buf = UnsafeMutablePointer<CChar>.init(allocatingCapacity: MAXLEN)
+            let buf = UnsafeMutablePointer<CChar>.allocate(capacity: MAXLEN)
             let len = fread(buf, strideof(CChar.self), MAXLEN, fp)
             if len < MAXLEN {
                 if ferror(fp) != 0 {
@@ -162,7 +162,7 @@ extension GPIO {
             //Remove the trailing \n
             buf[len-1]=0
             res = String.init(validatingUTF8: buf)
-            buf.deallocateCapacity(MAXLEN)
+            buf.deallocate(capacity: MAXLEN)
         }
         return res
     }


### PR DESCRIPTION
Currently using [Swift Nightly's](https://swiftnightly.com/) 07-23 build for the Pi. `UnsafeMutablePointer.init(allocatingCapacity:)` has been replaced with `UnsafeMutablePointer.allocate(capacity: )` and `UnsafeMutablePointer.deallocateCapacity()` has been replaced with `UnsafeMutablePointer.deallocate(capacity: )`. I have made the according changes to SwiftyGPIO.swift