### PR TITLE
use /dev/gpiomem instead of /dev/mem 

### DIFF
--- a/Sources/SwiftyGPIO.swift
+++ b/Sources/SwiftyGPIO.swift
@@ -246,9 +246,9 @@ public final class RaspiGPIO : GPIO {
     }
     
     private func initIO(_ id: Int){
-        let mem_fd = open("/dev/mem", O_RDWR | O_SYNC)
+        let mem_fd = open("/dev/gpiomem", O_RDWR | O_SYNC)
         guard (mem_fd > 0) else {
-            print("Can't open /dev/mem")
+            print("Can't open /dev/gpiomem")
             abort()
         }
         


### PR DESCRIPTION
using the /dev/gpiomem allows to run applications to all users in the gpio group, limiting the risk of granting permission on /dev/mem.