### PR TITLE
Bugfix i2c_smbus_write_block_data in I2C.swift

### DIFF
--- a/Sources/I2C.swift
+++ b/Sources/I2C.swift
@@ -387,7 +387,7 @@ public final class SysFSI2C: I2CInterface {
     private func i2c_smbus_write_block_data(command: UInt8, values: [UInt8]) -> Int32 {
         var data = [UInt8](repeating:0, count: I2C_MAX_LENGTH+1)
 
-        for i in 1..<values.count {
+        for i in 1...values.count {
             data[i] = values[i-1]
         }
         data[0] = UInt8(values.count)


### PR DESCRIPTION
Fixed a bug in the i2c_smbus_write_block_data function, where the last item of the values array would be dismissed, due to incorrect boundaries in the for loop.


### What's in this pull request?

Fixed a bug in the i2c_smbus_write_block_data function, where the last item of the values array would be dismissed, due to incorrect boundaries in the for loop. The bounds of the range of the for loop would exclude the last value and therefore in combination with the i-1 statement dismiss the last element of the array. This is now fixed.


### Is there something you want to discuss?

There is something wring with the i2c_smbus_read_block_data as well, like you mentioned in our slack chat, but I'm not certain what the exact problem is, so we might need to discuss that further before I can fix it.


### Pull Request Checklist

- [x] I've added a copyright header to every new file.
- [x] Every new file has been correctly indented, no tabs, 4 spaces (you can use swiftlint).
- [x] Verify that you only import what's necessary, this reduces compilation time.
- [x] Try to declare the type of every variable and constant, not using type inference greatly reduces compilation time.
- [x] Verify that your code compiles with the currently supported Swift version (currently 3.0.2 to support boards with Raspbian, don't use any 3.1 or 3.1.1 feature)
- [x] You've read the [contribution guidelines](https://github.com/uraimo/SwiftyGPIO/blob/master/CONTRIBUTING.md).

