### PR TITLE
Fix warning in Swift 3.2+

### DIFF
--- a/Sources/SwiftyGPIO.swift
+++ b/Sources/SwiftyGPIO.swift
@@ -172,7 +172,7 @@ fileprivate extension GPIO {
     func writeToFile(_ path: String, value: String) {
         let fp = fopen(path, "w")
         if fp != nil {
-          #if swift(>=4.0)
+          #if swift(>=3.2)
             let len = value.count
           #else
             let len = value.characters.count


### PR DESCRIPTION
`value.characters` is deprecated starting w/ 3.2. (produces
a warning, which this change avoids).
