### PR TITLE
Add SPM 4 package manifest, port code to 4

### DIFF
--- a/Package@swift-4.swift
+++ b/Package@swift-4.swift
@@ -1,0 +1,21 @@
+// swift-tools-version:4.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "SwiftyGPIO",
+    products: [
+        .library(
+            name: "SwiftyGPIO",
+            targets: ["SwiftyGPIO"]),
+    ],
+    dependencies: [
+    ],
+    targets: [
+        .target(
+            name: "SwiftyGPIO",
+            path: "Sources"
+        )
+    ]
+)

--- a/Sources/I2C.swift
+++ b/Sources/I2C.swift
@@ -111,7 +111,11 @@ public final class SysFSI2C: I2CInterface {
             perror("I2C read failed")
             abort()
         }
+      #if swift(>=4.0)
+        return UInt8(truncatingIfNeeded: r)
+      #else
         return UInt8(truncatingBitPattern: r)
+      #endif
     }
 
     public func readByte(_ address: Int, command: UInt8) -> UInt8 {
@@ -123,7 +127,11 @@ public final class SysFSI2C: I2CInterface {
             perror("I2C read failed")
             abort()
         }
+      #if swift(>=4.0)
+        return UInt8(truncatingIfNeeded: r)
+      #else
         return UInt8(truncatingBitPattern: r)
+      #endif
     }
 
     public func readWord(_ address: Int, command: UInt8) -> UInt16 {
@@ -135,7 +143,11 @@ public final class SysFSI2C: I2CInterface {
             perror("I2C read failed")
             abort()
         }
+      #if swift(>=4.0)
+        return UInt16(truncatingIfNeeded: r)
+      #else
         return UInt16(truncatingBitPattern: r)
+      #endif
     }
 
     public func readData(_ address: Int, command: UInt8) -> [UInt8] {

--- a/Sources/SwiftyGPIO.swift
+++ b/Sources/SwiftyGPIO.swift
@@ -225,8 +225,12 @@ fileprivate extension GPIO {
             var buf: [Int8] = [0, 0, 0] //Dummy read to discard current value
             read(fp, &buf, 3)
 
+          #if swift(>=4.0)
+            var pfd = pollfd(fd:fp, events:Int16(truncatingIfNeeded:POLLPRI), revents:0)
+          #else
             var pfd = pollfd(fd:fp, events:Int16(truncatingBitPattern:POLLPRI), revents:0)
-
+          #endif
+          
             while self.listening {
                 let ready = poll(&pfd, 1, -1)
                 if ready > -1 {


### PR DESCRIPTION
Add a `Package@swift-4.swift`, so that the package
compiles in Swift 4 mode.
Port the I2C/SwiftyGPIO files to compile with
Swift 4.

Swift 3 should still work just fine!