### PR TITLE
Smooth PWM Behavior when Changing Duty Cycles

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ First, we need to retrieve the list of GPIOs available on the board and get a re
 ```swift
 import SwiftyGPIO //Not needed when you compile via swiftc
 
-let gpios = SwiftyGPIO.GPIOs(for:.RaspberryPi2)
+let gpios = SwiftyGPIO.GPIOs(for:.RaspberryPi3)
 var gp = gpios[.P2]!
 ```
 
@@ -198,7 +198,7 @@ The other properties available on the GPIO object (edge,active low) refer to the
 GPIOs also support the execution of closures when the value of the pin changes. Closures can be added with `onRaising` (the pin value changed from 0 to 1), `onFalling` (the value changed from 1 to 0) and `onChange` (the value simply changed from the previous one):
 
 ```swift
-let gpios = SwiftyGPIO.GPIOs(for:.RaspberryPi2)
+let gpios = SwiftyGPIO.GPIOs(for:.RaspberryPi3)
 var gp = gpios[.P2]!
 
 
@@ -226,7 +226,7 @@ Setting the `bounceTime` property will enable software debounce, that will limit
 The following example allows only one transition every 500ms:
 
 ```swift
-let gpios = SwiftyGPIO.GPIOs(for:.RaspberryPi2)
+let gpios = SwiftyGPIO.GPIOs(for:.RaspberryPi3)
 var gp = gpios[.P2]!
 
 gp.bounceTime = 0.5
@@ -244,10 +244,10 @@ If your board has a SPI connection and SwiftyGPIO has it among its presets, a li
 
 On RaspberryPi and other boards the hardware SPI SysFS interface is not enabled by default, check out the setup guide on [wiki](https://github.com/uraimo/SwiftyGPIO/wiki/Enabling-SPI-on-RaspberryPi-and-others).
 
-Let's see some examples using a RaspberryPi 2 that has two bidirectional SPIs, managed by SwiftyGPIO as two SPIObjects:
+Let's see some examples using a RaspberryPi 3 that has two bidirectional SPIs, managed by SwiftyGPIO as two SPIObjects:
  
 ```swift
-let spis = SwiftyGPIO.hardwareSPIs(for:.RaspberryPi2)!
+let spis = SwiftyGPIO.hardwareSPIs(for:.RaspberryPi3)!
 var spi = spis[0]
 ```
 
@@ -257,7 +257,7 @@ Alternatively, we can create a software SPI using four GPIOs, one that will serv
 
 To create a software SPI, just retrieve two pins and create a `VirtualSPI` object:
 ```swift
-let gpios = SwiftyGPIO.GPIOs(for:.RaspberryPi2)
+let gpios = SwiftyGPIO.GPIOs(for:.RaspberryPi3)
 var cs = gpios[.P27]!
 var mosi = gpios[.P22]!
 var miso = gpios[.P4]!
@@ -295,7 +295,7 @@ The I2C interface can be used to communicate using the SMBus protocol on a I2C b
 To obtain a reference to the `I2CInterface` object, call the `hardwareI2Cs(for:)` utility method of the SwiftyGPIO class:
 
 ```swift
-let i2cs = SwiftyGPIO.hardwareI2Cs(for:.RaspberryPi2)!
+let i2cs = SwiftyGPIO.hardwareI2Cs(for:.RaspberryPi3)!
 let i2c = i2cs[1]
 ```
 
@@ -345,7 +345,7 @@ PWM output signals can be used to drive servo motors, RGB leds and other devices
 If your board has PWM ports and is supported (at the moment only RaspberryPi boards), retrieve the available `PWMOutput` objects with the `hardwarePWMs` factory method:
 
 ```swift
-let pwms = SwiftyGPIO.hardwarePWMs(for:.RaspberryPi2)!
+let pwms = SwiftyGPIO.hardwarePWMs(for:.RaspberryPi3)!
 let pwm = (pwms[0]?[.P18])!
 ```
 
@@ -414,7 +414,7 @@ In this brief guide I'm using an 8x8 led matrix with 64 WS2812 leds (these matri
 First of all let's retrieve a `PWMOutput` object and then initialize it:
 
 ```swift
-let pwms = SwiftyGPIO.hardwarePWMs(for:.RaspberryPi2)!
+let pwms = SwiftyGPIO.hardwarePWMs(for:.RaspberryPi3)!
 let pwm = (pwms[0]?[.P18])!
 
 // Initialize PWM
@@ -473,7 +473,7 @@ At this point you could configure a different signal calling again `initPWMPatte
 If your board support the UART serial ports feature (disable the login on serial with `raspi-config` for RaspberryPi boards), you can retrieve the list of available `UARTInterface` with `SwiftyGPIO.UARTs(for:)`:
 
 ```swift
-let uarts = SwiftyGPIO.UARTs(for:.RaspberryPi2)!
+let uarts = SwiftyGPIO.UARTs(for:.RaspberryPi3)!
 var uart = uarts[0]
 ```
 
@@ -501,7 +501,7 @@ A specific method that reads lines of text (`\n` is used as line terminator, the
 If your board provides a 1-Wire port (right now only RaspberryPi boards), you can retrieve the list of available `OneWireInterface` with `SwiftyGPIO.hardware1Wires(for:)`:
 
 ```swift
-let onewires = SwiftyGPIO.hardware1Wires(for:.RaspberryPi2)!
+let onewires = SwiftyGPIO.hardware1Wires(for:.RaspberryPi3)!
 var onewire = onewires[0]
 ```
 

--- a/README.md
+++ b/README.md
@@ -244,14 +244,14 @@ If your board has a SPI connection and SwiftyGPIO has it among its presets, a li
 
 On RaspberryPi and other boards the hardware SPI SysFS interface is not enabled by default, check out the setup guide on [wiki](https://github.com/uraimo/SwiftyGPIO/wiki/Enabling-SPI-on-RaspberryPi-and-others).
 
-Let's see some examples using a RaspberryPi 2 that has one bidirectional SPI, managed by SwiftyGPIO as two mono-directional SPIObjects:
+Let's see some examples using a RaspberryPi 2 that has two bidirectional SPIs, managed by SwiftyGPIO as two SPIObjects:
  
 ```swift
 let spis = SwiftyGPIO.hardwareSPIs(for:.RaspberryPi2)!
 var spi = spis[0]
 ```
 
-The items returned refer to different devices addressable through the SPI bus, the number is equal to the number of CS(or CE) pins available on your board.
+The interface is composed by 3 wire: a clock line (SCLK), an input line (MISO) and an output line (MOSI). One or more CS pins (with inverse logic) are available to enable or disable slave devices.
 
 Alternatively, we can create a software SPI using four GPIOs, one that will serve as clock pin (SCLK), one as chip-select (CS or CE) and the other two will be used to send and receive the actual data (MOSI and MISO). This kind of bit-banging SPI is slower than the hardware one, so, the recommended approach is to use hardware SPIs when available.
 

--- a/README.md
+++ b/README.md
@@ -586,7 +586,7 @@ A few projects and libraries built using SwiftyGPIO. Have you built something th
 * [Wii Nunchuck](https://github.com/uraimo/Nunchuck.swift) - A library for the Wii Nunchuck controller.
 * [RCWL-0516](https://github.com/uraimo/RCWL-0516-Radar.swift) - A Swift library for the RCWL-0516 Microwave Radar.
 * [DS18B20](https://github.com/uraimo/DS18B20.swift) - A library for the DS18B20 temperature sensor.
-
+* [PCA9685](https://github.com/Kaiede/PCA9685) - A library for the PCA9685 I2C PWM/Servo controller.
 
 ### Awesome Projects 
 * [Experimental Swift on the Raspberry Pi](https://medium.com/@piotr.gorzelany/experimental-swift-8c9131b62a9d) [(GH)](https://github.com/pgorzelany/experimental-swift-server) - Experimenting with Swift and a few different devices.

--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ var spi = VirtualSPI(mosiGPIO: mosi, misoGPIO: miso, clockGPIO: clk, csGPIO: cs)
 ```
 
 Both objects implement the same `SPIObject` protocol and so provide the same methods.
-To distinguish between hardware and software SPIObjects, use the `isHardware` method.
+To distinguish between hardware and software SPIObjects, use the `isHardware` property.
 
 To send one or more byte over a SPI, use the `sendData` method.
 In its simplest form it just needs an array of UInt8 as parameter:

--- a/Sources/I2C.swift
+++ b/Sources/I2C.swift
@@ -332,7 +332,7 @@ public final class SysFSI2C: I2CInterface {
                             size: I2C_SMBUS_WORD_DATA,
                             data: &data)
         if r >= 0 {
-            return (Int32(data[1]) << 8) + (Int32(data[0]) >> 8)
+            return (Int32(data[1]) << 8) + Int32(data[0])
         } else {
             return -1
         }

--- a/Sources/SPI.swift
+++ b/Sources/SPI.swift
@@ -79,7 +79,7 @@ public protocol SPIInterface {
     // Send data and then receive a chunck of data at the default frequency
     func sendDataAndRead(_ values: [UInt8]) -> [UInt8]
     // Returns true if the SPIInterface is using a real SPI pin, false if performing bit-banging
-    func isHardware() -> Bool
+    var isHardware: Bool { get }
 }
 
 /// Hardware SPI via SysFS
@@ -109,6 +109,8 @@ public final class SysFSSPI: SPIInterface {
         //TODO: Check if available?
     }
 
+    public var isHardware =  true
+
     public func sendData(_ values: [UInt8], frequencyHz: UInt = 500000) {
         if frequencyHz > 500000 {
             speed = UInt32(frequencyHz)
@@ -130,10 +132,6 @@ public final class SysFSSPI: SPIInterface {
 
     public func sendDataAndRead(_ values: [UInt8]) -> [UInt8] {
         return sendDataAndRead(values, frequencyHz: 500000)
-    }
-
-    public func isHardware() -> Bool {
-        return true
     }
 
     /// Write and read bits, will need a few dummy writes if you want only read
@@ -276,6 +274,8 @@ public final class VirtualSPI: SPIInterface {
         self.csGPIO.direction = .OUT
         self.csGPIO.value = 1
     }
+
+    public var isHardware =  true
 
     public func sendData(_ values: [UInt8], frequencyHz: UInt = 500000) {
         let mmapped = mosiGPIO.isMemoryMapped()
@@ -427,9 +427,6 @@ public final class VirtualSPI: SPIInterface {
         return value
     }
 
-    public func isHardware() -> Bool {
-        return false
-    }
 }
 
 // MARK: - SPI Constants


### PR DESCRIPTION
### What's in this pull request?

Changes how the PWM hardware is controlled in PWM.swift to make it possible to drive both channels at the same time and rapidly be able to change the duty cycle (pulsing, ramps, etc) on the PWM channels without excess flickering. 

### Is there something you want to discuss?

This PR doesn't attempt to modify the pattern writing behaviors at all, and only attempts to clean things up so that when going into pattern writing, you get the existing behavior, while the simpler PWM control gets the new behavior, with a bit of work tracking which mode the PHY is currently in. Unfortunately, I don't know how successful this change is. 

The highFreqSampleReduction behavior was broken by this change. I suspect something needs to be done here, but I'm not entirely sure what the correct approach should be. My particular scenario isn't interested in such high frequencies.

The implementation of phyFor(baseAddress:) is probably overkill. No app should really need more than one. 

### Pull Request Checklist

- [N/A] I've added a copyright header to every new file.
- [X] Every new file has been correctly indented, no tabs, 4 spaces (you can use swiftlint).
- [X] Verify that you only import what's necessary, this reduces compilation time.
- [X] Try to declare the type of every variable and constant, not using type inference greatly reduces compilation time.
- [TBD] Verify that your code compiles with the currently supported Swift version (currently 3.0.2 to support boards with Raspbian, don't use any 3.1 or 3.1.1 feature)
- [X] You've read the [contribution guidelines](https://github.com/uraimo/SwiftyGPIO/blob/master/CONTRIBUTING.md).


