### PR TITLE
Smoother PWM Behavior

### DIFF
--- a/Sources/PWM.swift
+++ b/Sources/PWM.swift
@@ -83,15 +83,18 @@ public protocol PWMOutput {
 }
 
 final public class RaspberryPHY {
-    private static var existingPhys: [Int: RaspberryPHY] = [:]
+    private static var existingPhy: RaspberryPHY? = nil
 
     static func phyFor(baseAddr: Int) -> RaspberryPHY {
-        if let phy = existingPhys[baseAddr] {
+        // If the physical base has changed, throw away the existing cache.
+        // This generally shouldn't happen, as the base address is fixed.
+        // It is reasonable to create a new instance if there is a mismatch, though.
+        if let phy = existingPhy, phy.BCM2708_PERI_BASE == baseAddr {
             return phy
         }
 
         let phy = RaspberryPHY(baseAddr: baseAddr)
-        existingPhys[baseAddr] = phy
+        existingPhy = phy
         return phy
     }
 

--- a/Sources/PWM.swift
+++ b/Sources/PWM.swift
@@ -105,7 +105,7 @@ final public class RaspberryPHY {
     var gpioBasePointer: UnsafeMutablePointer<UInt>!
     var pwmBasePointer: UnsafeMutablePointer<UInt>!
     var clockBasePointer: UnsafeMutablePointer<UInt>!
-    var dmaBasePointers: [UnsafeMutablePointer<UInt>]!
+    var dmaBasePointers: [UnsafeMutablePointer<UInt>]! = []
 
     public private(set) var isInitialized: Bool = false
     public private(set) var isReadyForPwm: Bool = false

--- a/Sources/PWM.swift
+++ b/Sources/PWM.swift
@@ -168,8 +168,9 @@ final public class RaspberryPHY {
 
     func killClock() {
         clockBasePointer.advanced(by: 40).pointee = CLKM_PASSWD | CLKM_CTL_KILL     //CM CTL register: Set KILL flag
-        isReadyForPwm = false
         usleep(10)
+
+        isReadyForPwm = false
     }
 
     /// Maps a block of memory and returns the pointer
@@ -376,9 +377,8 @@ extension RaspberryPWM {
         // Stop the PWM
         phy.pwmBasePointer.pointee = 0
         usleep(10)
-        // Stop the clock killing the clock
-        phy.clockBasePointer.advanced(by: 40).pointee = CLKM_PASSWD | CLKM_CTL_KILL     //Set KILL flag
-        usleep(10)
+        // Kill the Clock
+        phy.killClock()
 
         mailbox.cleanup()
     }
@@ -423,8 +423,7 @@ extension RaspberryPWM {
         phy.pwmBasePointer.pointee = 0
         usleep(10)
         // Stop the clock killing the clock
-        phy.clockBasePointer.advanced(by: 40).pointee = CLKM_PASSWD | CLKM_CTL_KILL     //Set KILL flag
-        usleep(10)
+        phy.killClock()
         // Check the BUSY flag, doesn't always work
         //while (clockBasePointer.advanced(by: 40).pointee & (1 << 7)) != 0 {}
 


### PR DESCRIPTION
### What's in this pull request?

Changes how the PWM hardware is controlled in PWM.swift to make it possible to drive both channels at the same time and rapidly be able to change the duty cycle (pulsing, ramps, etc) on the PWM channels without excess flickering. 

### Why a New Request?

I originally pulled from my fork's master instead of the work branch. This one uses the work branch, so it doesn't accidentally include unrelated changes, like my aarch64 fixes.

### Is there something you want to discuss?

This PR doesn't attempt to modify the pattern writing behaviors at all, and only attempts to clean things up so that when going into pattern writing, you get the existing behavior, while the simpler PWM control gets the new behavior, with a bit of work tracking which mode the PHY is currently in. Unfortunately, I don't know how successful this change is. 

### Pull Request Checklist

- [X] I've added a copyright header to every new file.
- [X] Every new file has been correctly indented, no tabs, 4 spaces (you can use swiftlint).
- [X] Verify that you only import what's necessary, this reduces compilation time.
- [X] Try to declare the type of every variable and constant, not using type inference greatly reduces compilation time.
- [X] Verify that your code compiles with the currently supported Swift version (currently 3.0.2 to support boards with Raspbian, don't use any 3.1 or 3.1.1 feature)
- [X] You've read the [contribution guidelines](https://github.com/uraimo/SwiftyGPIO/blob/master/CONTRIBUTING.md).

