### PR TITLE
Don't compile this on non-linux platforms

### DIFF
--- a/Sources/Mailbox.swift
+++ b/Sources/Mailbox.swift
@@ -180,7 +180,7 @@ public struct MailBox {
             perror("Failed to create mailbox device\n")
             return -1
         }
-      #else
+      #elseif os(Linux)
         if mknod(filename, S_IFCHR|0600, UInt(gnu_dev_makedev(100, 0))) < 0 {
             perror("Failed to create mailbox device\n")
             return -1


### PR DESCRIPTION
### What's in this pull request?

Just making sure that this doesn't try to get compiled on non-linux platforms

- [x] I've added a copyright header to every new file.
- [x] Every new file has been correctly indented, no tabs, 4 spaces (you can use swiftlint).
- [x] Verify that you only import what's necessary, this reduces compilation time.
- [x] Try to declare the type of every variable and constant, not using type inference greatly reduces compilation time.
- [x] Verify that your code compiles with the currently supported Swift version (currently 3.0.2 to support boards with Raspbian, don't use any 3.1 or 3.1.1 feature)
- [x] You've read the [contribution guidelines](https://github.com/uraimo/SwiftyGPIO/blob/master/CONTRIBUTING.md).


