### PR TITLE
Init in UART.swift missing return

### DIFF
--- a/Sources/SwiftyGPIO/Generic/UART.swift
+++ b/Sources/SwiftyGPIO/Generic/UART.swift
@@ -52,6 +52,7 @@ public final class SysFSUART: UARTInterface {
                 close(fd)
                 continue
             }
+            return
         }
         return nil
     }


### PR DESCRIPTION
### What's in this pull request?

Added missing return in init of UART.swift

### Pull Request Checklist

- [x] I've added the default copyright header to every new file.
- [x] Every new file has been correctly indented, no tabs, 4 spaces (you can use swiftlint).
- [x] Verify that you only import what's necessary, this reduces compilation time.
- [x] Try to declare the type of every variable and constant, not using type inference greatly reduces compilation time.
- [x] Verify that your code compiles with the currently supported Swift version (currently 4.1.3)
- [x] You've read the [contribution guidelines](https://github.com/uraimo/SwiftyGPIO/blob/master/CONTRIBUTING.md).


