### PR TITLE
UART Data Availability

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,10 +491,11 @@ func readData() -> [CChar]
 func writeString(_ value: String)
 func writeData(_ values: [CChar])
 
+func hasAvailableData() throws -> Bool
 func readLine() -> String
 ```
 
-A specific method that reads lines of text (`\n` is used as line terminator, the serial read is still non-canonical) is also provided.
+A method to know if there is available data on the UART serial port and a specific method that reads lines of text (`\n` is used as line terminator, the serial read is still non-canonical) are also provided.
 
 ### 1-Wire
 


### PR DESCRIPTION
### What's in this pull request?
Adds a helper method to the `UARTInterface` protocol in order to help users to know whether there is available data on the UART serial port, or not.

### Is there something you want to discuss?
Decided not to add the code to check for data availability in each of the current `read` methods so that users could decide if checking for availability is needed for them or not. 
The reason I added this method was because on the library I've been working on, there are some edge cases where data does not get send from one point to the other (or gets delayed) so whenever I called `readData`(and data was not there or delayed) my code would just get stuck in there forever. After some research, found out that [attempting to read from an empty pipe, by using **unistd**, **read** method, will block the process until data is available](https://linux.die.net/man/7/pipe).

### Pull Request Checklist

- [x] I've added the default copyright header to every new file.
- [x] Every new file has been correctly indented, no tabs, 4 spaces (you can use swiftlint).
- [x] Verify that you only import what's necessary, this reduces compilation time.
- [x] Try to declare the type of every variable and constant, not using type inference greatly reduces compilation time.
- [x] Verify that your code compiles with the currently supported Swift version (currently 4.1.3)
- [x] You've read the [contribution guidelines](https://github.com/uraimo/SwiftyGPIO/blob/master/CONTRIBUTING.md).


