### PR TITLE
UART Read Data Sleep

### DIFF
--- a/Sources/SwiftyGPIO/Generic/UART.swift
+++ b/Sources/SwiftyGPIO/Generic/UART.swift
@@ -117,9 +117,13 @@ public final class SysFSUART: UARTInterface {
         var buf = [CChar](repeating:0, count: 4096) //4096 chars at max in canonical mode
 
         let n = read(fd, &buf, buf.count * MemoryLayout<CChar>.stride)
+        
+        usleep(100_000) //100ms sleep. Workaround for random: Index out of range: .../ContiguousArrayBuffer.swift error
+
         if n<0 {
             throw UARTError.IOError("Error while reading from UART")
         }
+        
         return Array(buf[0..<n])
     }
 


### PR DESCRIPTION
### What's in this pull request?
Adds an `usleep` invocation right after the `read(fd, &buf, buf.count * MemoryLayout<CChar>.stride)` call on `readData` function on the **UART.swift** class in order to be able to fully read all the available data on the serial port before returning.

### Is there something you want to discuss?

For my SwiftyXBee library, I am checking whether there is available data on the serial port right before trying to read actual data from it; in order to avoid blocking my program in case there is no data available. Pretty often, I would be getting this crash: `Fatal error: Index out of range: file /home/buildSwiftOnARM/swift/stdlib/public/core/ContiguousArrayBuffer.swift, line 369` when calling `uart.hasAvailableData()` immediately followed by `uart.readData()`.
By trial an error, I found out that adding a 100ms sleep call right after the actual `read` method, would allow all the data to be read, so that `Array(buf[0..<n])` at the return of the `readData` method wouldn't cause me a crash. I know it is not the most elegant solution, but it does its job.

### Pull Request Checklist

- [x] I've added the default copyright header to every new file.
- [x] Every new file has been correctly indented, no tabs, 4 spaces (you can use swiftlint).
- [x] Verify that you only import what's necessary, this reduces compilation time.
- [x] Try to declare the type of every variable and constant, not using type inference greatly reduces compilation time.
- [x] Verify that your code compiles with the currently supported Swift version (currently 4.1.3)
- [x] You've read the [contribution guidelines](https://github.com/uraimo/SwiftyGPIO/blob/master/CONTRIBUTING.md).


