### PR TITLE
Addressing compiler warnings of using dangling pointers

### DIFF
--- a/Sources/1Wire.swift
+++ b/Sources/1Wire.swift
@@ -28,8 +28,6 @@
     import Darwin.C
 #endif
 
-import Foundation
-
 // MARK: - 1-Wire Presets
 extension SwiftyGPIO {
 

--- a/Sources/1Wire.swift
+++ b/Sources/1Wire.swift
@@ -28,6 +28,7 @@
     import Darwin.C
 #endif
 
+import Foundation
 
 // MARK: - 1-Wire Presets
 extension SwiftyGPIO {
@@ -102,27 +103,26 @@ public final class SysFSOneWire: OneWireInterface {
     }
 
     private func readLine(_ fd: Int32) -> String? {
-        var buf = [CChar](repeating:0, count: 128) 
-        var ptr = UnsafeMutablePointer<CChar>(&buf)
-        var pos = 0
-
-        repeat {
-            let n = read(fd, ptr, MemoryLayout<CChar>.stride)
-            if n<0 {
-                perror("Error while reading from 1-Wire interface")
-                abort()
-            } else if n == 0 {
-                break
+        var buf = [CChar](repeating:0, count: 128)
+        return buf.withUnsafeMutableBufferPointer  { ptr -> String? in
+            let newLineChar = CChar(UInt8(ascii: "\n"))
+            var pos = 0
+            repeat {
+                let n = read(fd, ptr.baseAddress! + pos, MemoryLayout<CChar>.stride)
+                if n<0 {
+                    perror("Error while reading from 1-Wire interface")
+                    abort()
+                } else if n == 0 {
+                    break
+                }
+                pos += 1
+            } while ptr[pos-1] != newLineChar
+            if pos == 0 {
+                return nil
+            } else {
+                ptr[pos-1] = 0
+                return String(cString: ptr.baseAddress!)
             }
-            ptr += 1
-            pos += 1
-        } while buf[pos-1] != CChar(UInt8(ascii: "\n"))
-
-        if pos == 0 {
-            return nil
-        } else {
-            buf[pos-1] = 0
-            return String(cString: &buf)
         }
     }
 

--- a/Sources/SPI.swift
+++ b/Sources/SPI.swift
@@ -86,8 +86,8 @@ public protocol SPIInterface {
 public final class SysFSSPI: SPIInterface {
 
     struct spi_ioc_transfer {
-        var tx_buf: UInt64
-        var rx_buf: UInt64
+        var tx_buf: UnsafeMutableRawPointer
+        var rx_buf: UnsafeMutableRawPointer
         var len: UInt32
         var speed_hz: UInt32 = 500000
         var delay_usecs: UInt16 = 0
@@ -137,22 +137,26 @@ public final class SysFSSPI: SPIInterface {
     /// Write and read bits, will need a few dummy writes if you want only read
     @discardableResult
     private func transferData(_ path: String, tx: [UInt8]) -> [UInt8] {
-        let rx: [UInt8] = [UInt8](repeating:0, count: tx.count)
-
         let fd = open(path, O_RDWR)
         guard fd > 0 else {
             fatalError("Couldn't open the SPI device")
         }
 
-        var tr = spi_ioc_transfer(
-            tx_buf: UInt64( UInt(bitPattern: UnsafeMutablePointer(mutating: tx)) ),
-            rx_buf: UInt64( UInt(bitPattern: UnsafeMutablePointer(mutating: rx)) ),
-            len: UInt32(tx.count),
-            speed_hz: speed,
-            delay_usecs: delay,
-            bits_per_word: bits)
+        var tx = tx
+        var rx: [UInt8] = [UInt8](repeating:0, count: tx.count)
 
-        let r = ioctl(fd, SPI_IOC_MESSAGE1, &tr)
+        let r = tx.withUnsafeMutableBufferPointer { txPtr -> CInt in
+            return rx.withUnsafeMutableBufferPointer { rxPtr -> CInt in
+                var tr = spi_ioc_transfer(
+                    tx_buf: txPtr.baseAddress!,
+                    rx_buf: rxPtr.baseAddress!,
+                    len: UInt32(txPtr.count),
+                    speed_hz: speed,
+                    delay_usecs: delay,
+                    bits_per_word: bits)
+                return ioctl(fd, SPI_IOC_MESSAGE1, &tr)
+            }
+        }
         if r < 1 {
             perror("Couldn't send spi message")
             abort()


### PR DESCRIPTION
### What's in this pull request?

Addressing compiler warnings of using dangling pointers.
### Is there something you want to discuss?

n/a


### Pull Request Checklist

- [ ] I've added the default copyright header to every new file.
- [ ] Every new file has been correctly indented, no tabs, 4 spaces (you can use swiftlint).
- [ ] Verify that you only import what's necessary, this reduces compilation time.
- [ ] Try to declare the type of every variable and constant, not using type inference greatly reduces compilation time.
- [ ] Verify that your code compiles with the currently supported Swift version (currently 4.1.3)
- [ ] You've read the [contribution guidelines](https://github.com/uraimo/SwiftyGPIO/blob/master/CONTRIBUTING.md).


