### PR TITLE
Gets rid of not needed fallthrough in switch statements

### DIFF
--- a/Sources/ADC.swift
+++ b/Sources/ADC.swift
@@ -42,16 +42,6 @@ extension SwiftyGPIO {
         switch board {
         case .BeagleBoneBlack:
             return [ADCBBB[0]!, ADCBBB[1]!, ADCBBB[2]!, ADCBBB[3]!]
-        case .RaspberryPiRev1:
-            fallthrough
-        case .RaspberryPiRev2:
-            fallthrough
-        case .RaspberryPiPlusZero:
-            fallthrough
-        case .RaspberryPi2:
-            fallthrough
-        case .RaspberryPi3:
-            fallthrough
         default:
             return nil
         }

--- a/Sources/I2C.swift
+++ b/Sources/I2C.swift
@@ -34,15 +34,11 @@ extension SwiftyGPIO {
         switch board {
         case .CHIP:
             return [I2CCHIP[1]!, I2CCHIP[2]!]
-        case .RaspberryPiRev1:
-            fallthrough
-        case .RaspberryPiRev2:
-            fallthrough
-        case .RaspberryPiPlusZero:
-            fallthrough
-        case .RaspberryPi2:
-            fallthrough
-        case .RaspberryPi3:
+        case .RaspberryPiRev1,
+             .RaspberryPiRev2,
+             .RaspberryPiPlusZero,
+             .RaspberryPi2,
+             .RaspberryPi3:
             return [I2CRPI[0]!, I2CRPI[1]!]
         default:
             return nil

--- a/Sources/PWM.swift
+++ b/Sources/PWM.swift
@@ -33,15 +33,9 @@ extension SwiftyGPIO {
 
     public static func hardwarePWMs(for board: SupportedBoard) -> [Int:[GPIOName:PWMOutput]]? {
         switch board {
-        case .RaspberryPiRev1:
-            fallthrough
-        case .RaspberryPiRev2:
-            fallthrough
-        case .RaspberryPiPlusZero:
+        case .RaspberryPiRev1, .RaspberryPiRev2, .RaspberryPiPlusZero:
             return PWMRPI1
-        case .RaspberryPi2:
-            fallthrough
-        case .RaspberryPi3:
+        case .RaspberryPi2, .RaspberryPi3:
             return PWMRPI23
         case .RaspberryPi4:
             return PWMRPI4

--- a/Sources/SPI.swift
+++ b/Sources/SPI.swift
@@ -34,15 +34,11 @@ extension SwiftyGPIO {
         switch board {
         case .CHIP:
             return [SPICHIP[0]!]
-        case .RaspberryPiRev1:
-            fallthrough
-        case .RaspberryPiRev2:
-            fallthrough
-        case .RaspberryPiPlusZero:
-            fallthrough
-        case .RaspberryPi2:
-            fallthrough
-        case .RaspberryPi3:
+        case .RaspberryPiRev1,
+             .RaspberryPiRev2,
+             .RaspberryPiPlusZero,
+             .RaspberryPi2,
+             .RaspberryPi3:
             return [SPIRPI[0]!, SPIRPI[1]!]
         default:
             return nil

--- a/Sources/SwiftyGPIO.swift
+++ b/Sources/SwiftyGPIO.swift
@@ -433,9 +433,7 @@ public struct SwiftyGPIO {
             return GPIORPIRev2
         case .RaspberryPiPlusZero:
             return GPIORPIPlusZERO
-        case .RaspberryPi2:
-            fallthrough
-        case .RaspberryPi3:
+        case .RaspberryPi2, .RaspberryPi3:
             return GPIORPI2
         case .RaspberryPi4:
             return GPIORPI4

--- a/Sources/UART.swift
+++ b/Sources/UART.swift
@@ -34,13 +34,10 @@ extension SwiftyGPIO {
         switch board {
         case .CHIP:
             return [SysFSUART(["serial0","ttyAMA0"])!]
-        case .RaspberryPiRev1:
-            fallthrough
-        case .RaspberryPiRev2:
-            fallthrough
-        case .RaspberryPiPlusZero:
-            fallthrough
-        case .RaspberryPi2:
+        case .RaspberryPiRev1,
+             .RaspberryPiRev2,
+             .RaspberryPiPlusZero,
+             .RaspberryPi2:
             return [SysFSUART(["serial0","ttyAMA0"])!]
         case .RaspberryPi3:
             return [SysFSUART(["serial0","ttyS0"])!,


### PR DESCRIPTION
### What's in this pull request?


### Is there something you want to discuss?



### Pull Request Checklist

- [ ] I've added the default copyright header to every new file.
- [ ] Every new file has been correctly indented, no tabs, 4 spaces (you can use swiftlint).
- [ ] Verify that you only import what's necessary, this reduces compilation time.
- [ ] Try to declare the type of every variable and constant, not using type inference greatly reduces compilation time.
- [ ] Verify that your code compiles with the currently supported Swift version (currently 4.1.3)
- [ ] You've read the [contribution guidelines](https://github.com/uraimo/SwiftyGPIO/blob/master/CONTRIBUTING.md).


