### PR TITLE
Refactor func makeInterruptThread of GPIO to avoid creating string instance

### DIFF
--- a/Sources/SwiftyGPIO.swift
+++ b/Sources/SwiftyGPIO.swift
@@ -228,7 +228,7 @@ fileprivate extension GPIO {
             self.edge = .BOTH
 
             let fp = open(gpath, O_RDWR)
-            var buf: [Int8] = [0, 0, 0]
+            var buf: [UInt8] = [0, 0, 0]
             read(fp, &buf, 3) //Dummy read to discard current value
 
           #if swift(>=4.0)
@@ -242,13 +242,10 @@ fileprivate extension GPIO {
                 if ready > -1 {
                     lseek(fp, 0, SEEK_SET)
                     read(fp, &buf, 2)
-                    buf[1]=0
-
-                    let res = String(validatingUTF8: buf)!
-                    switch res {
-                    case "0":
+                    switch buf[0] {
+                    case Character("0").asciiValue:
                         self.interrupt(type: &(self.intFalling))
-                    case "1":
+                    case Character("1").asciiValue:
                         self.interrupt(type: &(self.intRaising))
                     default:
                         break


### PR DESCRIPTION
### What's in this pull request?

Refactor func makeInterruptThread of GPIO to avoid creating string instance

### Is there something you want to discuss?



### Pull Request Checklist

- [ ] I've added the default copyright header to every new file.
- [ ] Every new file has been correctly indented, no tabs, 4 spaces (you can use swiftlint).
- [ ] Verify that you only import what's necessary, this reduces compilation time.
- [ ] Try to declare the type of every variable and constant, not using type inference greatly reduces compilation time.
- [ ] Verify that your code compiles with the currently supported Swift version (currently 4.1.3)
- [ ] You've read the [contribution guidelines](https://github.com/uraimo/SwiftyGPIO/blob/master/CONTRIBUTING.md).


