### PR TITLE
Simplify switch using UInt8 instead of Character.asciiValue

### DIFF
--- a/Sources/SwiftyGPIO.swift
+++ b/Sources/SwiftyGPIO.swift
@@ -236,9 +236,9 @@ fileprivate extension GPIO {
                     lseek(fp, 0, SEEK_SET)
                     read(fp, &buf, 2)
                     switch buf[0] {
-                    case Character("0").asciiValue:
+                    case UInt8(ascii: "0"):
                         self.interrupt(type: &(self.intFalling))
-                    case Character("1").asciiValue:
+                    case UInt8(ascii: "1"):
                         self.interrupt(type: &(self.intRaising))
                     default:
                         break


### PR DESCRIPTION
### What's in this pull request?

Simplify switch using UInt8 instead of Character.asciiValue

### Is there something you want to discuss?


### Pull Request Checklist

- [ ] I've added the default copyright header to every new file.
- [ ] Every new file has been correctly indented, no tabs, 4 spaces (you can use swiftlint).
- [ ] Verify that you only import what's necessary, this reduces compilation time.
- [ ] Try to declare the type of every variable and constant, not using type inference greatly reduces compilation time.
- [ ] Verify that your code compiles with the currently supported Swift version (currently 4.1.3)
- [ ] You've read the [contribution guidelines](https://github.com/uraimo/SwiftyGPIO/blob/master/CONTRIBUTING.md).


