### PR TITLE
Add .RaspberryPi4 as valid enum case for I2C interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Examples of  *[device libraries](#libraries)* and *[complete projects](#awesome-
 
 The following boards are supported and have been tested with recent releases of Swift:
 
-* Raspberry Pi 4
+* Raspberry Pi 4, 4B
 * Raspberry Pi 3, 3A+, 3B+
 * Raspberry Pi 2 (Thanks to [@iachievedit](https://twitter.com/iachievedit))
 * Raspberry Pi Zero W

--- a/Sources/I2C.swift
+++ b/Sources/I2C.swift
@@ -38,7 +38,8 @@ extension SwiftyGPIO {
              .RaspberryPiRev2,
              .RaspberryPiPlusZero,
              .RaspberryPi2,
-             .RaspberryPi3:
+             .RaspberryPi3,
+             .RaspberryPi4:
             return [I2CRPI[0]!, I2CRPI[1]!]
         default:
             return nil

--- a/Sources/SwiftyGPIO.swift
+++ b/Sources/SwiftyGPIO.swift
@@ -444,7 +444,7 @@ public enum SupportedBoard: String {
     case RaspberryPiPlusZero // Pi A+,B+,Zero with 40 pin header
     case RaspberryPi2 // Pi 2 with 40 pin header
     case RaspberryPi3 // Pi 3 with 40 pin header
-    case RaspberryPi4 // Pi 3 with 40 pin header
+    case RaspberryPi4 // Pi 4 with 40 pin header
     case CHIP
     case BeagleBoneBlack
     case OrangePi


### PR DESCRIPTION
### What's in this pull request?

Small change to add .RaspberryPi4 as a valid enum case for the same I2C interfaces as Pi3.  Without it, calls to `SwiftyGPIO.hardwareI2Cs(for:.RaspberryPi4)` will return nil, though the I2C implementation is valid for Pi4 and Pi4B.

There is also one small comment typo fix for what looks to be a copy/paste of Pi3 to Pi4 in the global enums.

Lastly a minor README add to mention Pi 4B support, which I have been using for general GPIO and I2C integration with PCA 9685 and GY-521 (MPU 6050) modules.

### Is there something you want to discuss?

Tested with [MPU-6050.swift](https://github.com/uraimo/MPU-6050.swift) on default address (`0x68`)

Tested with [PCA9685](https://github.com/Kaiede/PCA9685.git) on default address (`0x40`)

```

     0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
00:          -- -- -- -- -- -- -- -- -- -- -- -- -- 
10: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
20: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
30: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
40: 40 -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
50: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
60: -- -- -- -- -- -- -- -- 68 -- -- -- -- -- -- -- 
70: 70 -- -- -- -- -- -- --

```

#### Built On

**Swift 5.3.2 on macOS 11.1**

```
Apple Swift version 5.3.2 (swiftlang-1200.0.45 clang-1200.0.32.28)
Target: x86_64-apple-darwin20.2.0
```

**Swift 5.1.5 on Raspbian 10 (buster) 32 bit**

```
Swift version 5.1.5 (swift-5.1.5-RELEASE)
Target: armv6-unknown-linux-gnueabihf
```

### Pull Request Checklist

- [X] I've added the default copyright header to every new file.
- [X] Every new file has been correctly indented, no tabs, 4 spaces (you can use swiftlint).
- [X] Verify that you only import what's necessary, this reduces compilation time.
- [X] Try to declare the type of every variable and constant, not using type inference greatly reduces compilation time.
- [X] Verify that your code compiles with the currently supported Swift version (currently 4.1.3)
- [X] You've read the [contribution guidelines](https://github.com/uraimo/SwiftyGPIO/blob/master/CONTRIBUTING.md).
