### PR TITLE
Fix readFromFile removing newline when fread returns 0

### DIFF
--- a/Sources/SwiftyGPIO.swift
+++ b/Sources/SwiftyGPIO.swift
@@ -202,9 +202,8 @@ fileprivate extension GPIO {
                     abort()
                 }
             }
-            // Remove the trailing \n
-            buffer[len-1] = 0
-            return String(validatingUTF8: buffer.baseAddress!.assumingMemoryBound(to: CChar.self))
+
+            return String(validatingUTF8: buffer.baseAddress!.assumingMemoryBound(to: CChar.self))?.trimmingCharacters(in: .newlines)
         }
     }
 


### PR DESCRIPTION
### What's in this pull request?

Describe the content of this pull request. 

When reading a file with fread, it is possible for it to return 0 if you reach the EOF which would cause removing the newline character to crash.

> On success, fread() and fwrite() return the number of items read
       or written.  This number equals the number of bytes transferred
       only when size is 1.  If an error occurs, or the end of the file
       is reached, the return value is a short item count (or zero).


If it's a new feature, do you plan to create additional PRs based on this one in the future to add additional functionalities?


### Is there something you want to discuss?

Is there something you are unsure of or something you'd like to discuss before merging the final version of this PR?


### Pull Request Checklist

- [ ] I've added the default copyright header to every new file.
- [ ] Every new file has been correctly indented, no tabs, 4 spaces (you can use swiftlint).
- [ ] Verify that you only import what's necessary, this reduces compilation time.
- [ ] Try to declare the type of every variable and constant, not using type inference greatly reduces compilation time.
- [ ] Verify that your code compiles with the currently supported Swift version (currently 4.1.3)
- [ ] You've read the [contribution guidelines](https://github.com/uraimo/SwiftyGPIO/blob/master/CONTRIBUTING.md).


