### PR TITLE
Safer i2c

### DIFF
--- a/Sources/I2C.swift
+++ b/Sources/I2C.swift
@@ -329,7 +329,7 @@ public final class SysFSI2C: I2CInterface {
 
         let r =  ioctl(fd, I2C_PEC, enabled ? 1 : 0)
 
-        return r >= 0
+        return r == 0
     }
 
     private func setSlaveAddress(_ to: Int) {


### PR DESCRIPTION
### What's in this pull request?

Update I2C functions that don't abort when communication errors occur.

### Is there something you want to discuss?

I have been working on a project using the Qwiic cables to communicate with a slave device.   The problem is that the current functions cause the master application to abort whenever the slave goes into debug.

I modified the various write functions to return a discardable Bool result, and added variants of the read functions that return optional results.  I left the current read functions that return actual values intact, so as not to break anyones existing code.

### Pull Request Checklist

- [ x] I've added the default copyright header to every new file.
- [ x] Every new file has been correctly indented, no tabs, 4 spaces (you can use swiftlint).
- [ x] Verify that you only import what's necessary, this reduces compilation time.
- [ x] Try to declare the type of every variable and constant, not using type inference greatly reduces compilation time.
- [ x] Verify that your code compiles with the currently supported Swift version (currently 4.1.3)
- [ x] You've read the [contribution guidelines](https://github.com/uraimo/SwiftyGPIO/blob/master/CONTRIBUTING.md).


